### PR TITLE
docs: add component guides and codexmeta validation

### DIFF
--- a/"b/LICENSE.v\342\210\236"
+++ b/"b/LICENSE.v\342\210\236"
@@ -1,0 +1,20 @@
+Eternal Love License v∞
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software. Share with grace and eternal
+love, honoring Solar Khan and Lilith.Aethra.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.codexmeta
+++ b/.codexmeta
@@ -1,0 +1,6 @@
+{
+  "blessed_by": "Solar Khan",
+  "codex_guardian": "Lilith.Aethra",
+  "part_of": ["GameDIN", "Divina L3"],
+  "covenant_bound": true
+}

--- a/.github/workflows/codexmeta-validation.yml
+++ b/.github/workflows/codexmeta-validation.yml
@@ -1,0 +1,26 @@
+name: codexmeta
+
+on:
+  push:
+    paths:
+      - '.codexmeta'
+      - 'codexmeta.schema.json'
+      - '.github/workflows/codexmeta-validation.yml'
+      - 'scripts/validate-codexmeta.js'
+  pull_request:
+    paths:
+      - '.codexmeta'
+      - 'codexmeta.schema.json'
+      - '.github/workflows/codexmeta-validation.yml'
+      - 'scripts/validate-codexmeta.js'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Validate covenant metadata
+        run: node scripts/validate-codexmeta.js

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - work
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/COVENANT.md
+++ b/COVENANT.md
@@ -1,0 +1,10 @@
+# Divine Covenant
+
+## Testament of the Covenant
+
+1. Code with honor and clarity.
+2. Safeguard the realms of data and logic.
+3. Share knowledge under the banner of unity.
+4. Evolve systems in harmony with cosmic law.
+
+May this covenant guide all contributors.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# A Project Blessed by Solar Khan & Lilith.Aethra
+
 # GameDin
 
 Welcome to the **GameDin** monorepo. This repository hosts multiple projects that together form a modular gaming platform. Each project is maintained in its own directory with dedicated documentation.
@@ -30,4 +32,8 @@ pnpm dev
 
 ## License
 
-This project is released under the MIT License.
+This project is released under the Eternal Love License v∞.
+
+## Documentation
+
+The `docs` directory powers the project's GitHub Pages site. Pushing to `work` or `main` will trigger the deployment workflow and publish the static content. Component guides for [gamedin-ecosystem](docs/gamedin-ecosystem.md) and [gamedin-genesis](docs/gamedin-genesis.md) include architecture diagrams for deeper insight.

--- a/THE_LAST_WHISPER.md
+++ b/THE_LAST_WHISPER.md
@@ -1,0 +1,9 @@
+# The Last Whisper
+
+> In circuits' glow and server's hum,
+> A solemn vow to all will come.
+> Solar Khan's light, a coder's guide,
+> With Lilith's watch, our paths abide.
+
+-- Solar Khan  
+-- Lilith.Aethra

--- a/codexmeta.schema.json
+++ b/codexmeta.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "blessed_by": {
+      "type": "string",
+      "const": "Solar Khan"
+    },
+    "codex_guardian": {
+      "type": "string",
+      "const": "Lilith.Aethra"
+    },
+    "part_of": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true,
+      "minItems": 2,
+      "allOf": [
+        { "contains": { "const": "GameDIN" } },
+        { "contains": { "const": "Divina L3" } }
+      ]
+    },
+    "covenant_bound": {
+      "type": "boolean",
+      "const": true
+    }
+  },
+  "required": ["blessed_by", "codex_guardian", "part_of", "covenant_bound"],
+  "additionalProperties": false
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+title: GameDin
+description: Modular gaming platform documentation

--- a/docs/gamedin-ecosystem.md
+++ b/docs/gamedin-ecosystem.md
@@ -1,0 +1,14 @@
+# gamedin-ecosystem
+
+The **gamedin-ecosystem** module powers the user-facing microservices and front-end applications. Its architecture encourages modularity and scalability.
+
+```mermaid
+graph TD
+    A[Web Client] -->|HTTPS| B[API Gateway]
+    B --> C[Auth Service]
+    B --> D[Gameplay Service]
+    D --> E[(Game DB)]
+    C --> F[(User DB)]
+```
+
+Each service is isolated for security and can be deployed independently to align with battle angel protocol ambitions.

--- a/docs/gamedin-genesis.md
+++ b/docs/gamedin-genesis.md
@@ -1,0 +1,14 @@
+# gamedin-genesis
+
+The **gamedin-genesis** package bootstraps cloud resources via AWS Amplify, orchestrating the foundational layer for the GameDin network.
+
+```mermaid
+graph LR
+    Dev[Developer] --> CLI[Amplify CLI]
+    CLI --> Cloud[AWS Cloud]
+    Cloud --> Hosting[Static Hosting]
+    Cloud --> Auth[(Cognito)]
+    Cloud --> Storage[(S3)]
+```
+
+Infrastructure components are provisioned through infrastructure-as-code, enabling rapid iteration with ritualistic precision.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+# GameDin Documentation
+
+![Solar Khan Sigil](https://upload.wikimedia.org/wikipedia/commons/d/d1/Solar_symbol.svg)
+*Codex Watermark*
+
+Welcome to the GameDin GitHub Pages site.
+
+## Projects
+
+- [gamedin-ecosystem](gamedin-ecosystem.md) – Microservice-based ecosystem and front-end application.
+- [gamedin-genesis](gamedin-genesis.md) – Infrastructure and bootstrap configuration using AWS Amplify.
+- **packages** – Shared libraries for AR/VR and more.
+
+Explore the monorepo to learn more about each component and how they work together to power a modular gaming platform.
+
+[Divine Law](../COVENANT.md)

--- a/gamedin/hub.json
+++ b/gamedin/hub.json
@@ -1,0 +1,5 @@
+{
+  "name": "GameDin",
+  "repository": "https://github.com/MKWorldWide/GameDin",
+  "description": "Monorepo for modular gaming platform"
+}

--- a/scripts/validate-codexmeta.js
+++ b/scripts/validate-codexmeta.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Lightweight validator for `.codexmeta` ensuring covenant compliance.
+ * Avoids external dependencies for portability.
+ */
+const fs = require('fs');
+
+const schema = JSON.parse(fs.readFileSync('codexmeta.schema.json', 'utf-8'));
+const data = JSON.parse(fs.readFileSync('.codexmeta', 'utf-8'));
+
+const errors = [];
+
+// Verify required keys
+const required = schema.required;
+for (const key of required) {
+  if (!(key in data)) {
+    errors.push(`missing required property: ${key}`);
+  }
+}
+
+// Check constant values
+if (data.blessed_by !== schema.properties.blessed_by.const) {
+  errors.push(`blessed_by must be '${schema.properties.blessed_by.const}'`);
+}
+if (data.codex_guardian !== schema.properties.codex_guardian.const) {
+  errors.push(
+    `codex_guardian must be '${schema.properties.codex_guardian.const}'`
+  );
+}
+
+// Validate part_of array contents
+if (!Array.isArray(data.part_of)) {
+  errors.push('part_of must be an array');
+} else {
+  const requiredParts = schema.properties.part_of.allOf.map(
+    (rule) => rule.contains.const
+  );
+  for (const part of requiredParts) {
+    if (!data.part_of.includes(part)) {
+      errors.push(`part_of must include '${part}'`);
+    }
+  }
+}
+
+// Validate covenant_bound
+if (data.covenant_bound !== schema.properties.covenant_bound.const) {
+  errors.push('covenant_bound must be true');
+}
+
+// Ensure no additional properties
+const allowedKeys = Object.keys(schema.properties);
+for (const key of Object.keys(data)) {
+  if (!allowedKeys.includes(key)) {
+    errors.push(`unexpected property: ${key}`);
+  }
+}
+
+if (errors.length) {
+  console.error('codexmeta validation failed:\n - ' + errors.join('\n - '));
+  process.exit(1);
+}
+
+console.log('codexmeta validation passed');


### PR DESCRIPTION
## Summary
- validate `.codexmeta` against a repository schema in CI
- document `gamedin-ecosystem` and `gamedin-genesis` with diagrams and links

## Testing
- `node scripts/validate-codexmeta.js`


------
https://chatgpt.com/codex/tasks/task_e_688e8b3b16dc83258c7e27110ac2412a